### PR TITLE
Ehinrichs/ errors on Windows compile

### DIFF
--- a/fehmpytests/tpl_write/asteval.py
+++ b/fehmpytests/tpl_write/asteval.py
@@ -149,14 +149,14 @@ class Interpreter:
     def raise_exception(self, node, exc=None, msg='', expr=None,
                         lineno=None):
         "add an exception"
-        if self.error is None:
+        if self.error == None:
             self.error = []
-        if expr  is None:
+        if expr  == None:
             expr  = self.expr
 
         if len(self.error) > 0 and not isinstance(node, ast.Module):
             msg = '%s' % msg
-        if self.errmsg is None:
+        if self.errmsg == None:
             self.errmsg = msg
         err = ExceptionHolder(node, exc=exc, msg=self.errmsg,
                               expr=expr, lineno=lineno)
@@ -183,14 +183,14 @@ class Interpreter:
         #    run(None) and expect a None in return.
         if len(self.error)>0:
             return
-        if node is None:
+        if node == None:
             return None
         if isinstance(node, str):
             node = self.parse(node)
-        if lineno is not None:
+        if lineno != None:
             self.lineno = lineno
 
-        if expr   is not None:
+        if expr   != None:
             self.expr   = expr
 
         # get handler for this node:
@@ -256,7 +256,7 @@ class Interpreter:
     def on_return(self, node): # ('value',)
         "return statement: look for None, return special sentinal"
         self.retval = self.run(node.value)
-        if self.retval is None:
+        if self.retval == None:
             self.retval = ReturnedNone
         return
 
@@ -518,7 +518,7 @@ class Interpreter:
             self._interrupt = None
             for tnode in node.body:
                 self.run(tnode)
-                if self._interrupt is not None:
+                if self._interrupt != None:
                     break
             if isinstance(self._interrupt, ast.Break):
                 break
@@ -534,7 +534,7 @@ class Interpreter:
             self._interrupt = None
             for tnode in node.body:
                 self.run(tnode)
-                if self._interrupt is not None:
+                if self._interrupt != None:
                     break
             if isinstance(self._interrupt, ast.Break):
                 break
@@ -571,11 +571,11 @@ class Interpreter:
                 e_type, e_value, e_tback = self.error[-1].exc_info
                 for hnd in node.handlers:
                     htype = None
-                    if hnd.type is not None:
+                    if hnd.type != None:
                         htype = __builtins__.get(hnd.type.id, None)
-                    if htype is None or isinstance(e_type(), htype):
+                    if htype == None or isinstance(e_type(), htype):
                         self.error = []
-                        if hnd.name is not None:
+                        if hnd.name != None:
                             self.node_assign(hnd.name, e_value)
                         for tline in hnd.body:
                             self.run(tline)
@@ -608,7 +608,7 @@ class Interpreter:
             self.raise_exception(node, exc=TypeError, msg=msg)
 
         args = [self.run(targ) for targ in node.args]
-        if node.starargs is not None:
+        if node.starargs != None:
             args = args + self.run(node.starargs)
 
         keywords = {}
@@ -618,7 +618,7 @@ class Interpreter:
                 self.raise_exception(node, msg=msg)
 
             keywords[key.arg] = self.run(key.value)
-        if node.kwargs is not None:
+        if node.kwargs != None:
             keywords.update(self.run(node.kwargs))
 
         try:
@@ -688,7 +688,7 @@ class Procedure(object):
         sig = ""
         if len(self.argnames) > 0:
             sig = "%s%s" % (sig, ', '.join(self.argnames))
-        if self.vararg is not None:
+        if self.vararg != None:
             sig = "%s, *%s" % (sig, self.vararg)
         if len(self.kwargs) > 0:
             if len(sig) > 0:
@@ -696,10 +696,10 @@ class Procedure(object):
             _kw = ["%s=%s" % (k, v) for k, v in self.kwargs]
             sig = "%s%s" % (sig, ', '.join(_kw))
 
-        if self.varkws is not None:
+        if self.varkws != None:
             sig = "%s, **%s" % (sig, self.varkws)
         sig = "<Procedure %s(%s)>" % (self.name, sig)
-        if self.__doc__ is not None:
+        if self.__doc__ != None:
             sig = "%s\n  %s" % (sig, self.__doc__)
         return sig
 
@@ -719,7 +719,7 @@ class Procedure(object):
             n_names = len(self.argnames)
             n_kws = len(kwargs)
 
-        if len(self.argnames) > 0 and kwargs is not None:
+        if len(self.argnames) > 0 and kwargs != None:
             msg = "multiple values for keyword argument '%s' in Procedure %s"
             for targ in self.argnames:
                 if targ in kwargs:
@@ -739,7 +739,7 @@ class Procedure(object):
             symlocals[argname] = args.pop(0)
 
         try:
-            if self.vararg is not None:
+            if self.vararg != None:
                 symlocals[self.vararg] = tuple(args)
 
             for key, val in self.kwargs:
@@ -747,7 +747,7 @@ class Procedure(object):
                     val = kwargs.pop(key)
                 symlocals[key] = val
 
-            if self.varkws is not None:
+            if self.varkws != None:
                 symlocals[self.varkws] = kwargs
 
             elif len(kwargs) > 0:
@@ -771,9 +771,9 @@ class Procedure(object):
             self.interpreter.run(node, expr='<>', lineno=self.lineno)
             if len(self.interpreter.error) > 0:
                 break
-            if self.interpreter.retval is not None:
+            if self.interpreter.retval != None:
                 retval = self.interpreter.retval
-                if retval is ReturnedNone: retval = None
+                if retval == ReturnedNone: retval = None
                 break
 
         self.interpreter.symtable = save_symtable

--- a/fehmpytests/tpl_write/astutils.py
+++ b/fehmpytests/tpl_write/astutils.py
@@ -145,15 +145,15 @@ class ExceptionHolder(object):
         self.exc    = exc
         self.lineno = lineno
         self.exc_info = exc_info()
-        if self.exc is None and self.exc_info[0] is not None:
+        if self.exc == None and self.exc_info[0] != None:
             self.exc = self.exc_info[0]
-        if self.msg is '' and self.exc_info[1] is not None:
+        if self.msg == '' and self.exc_info[1] != None:
             self.msg = self.exc_info[1]
 
     def get_error(self):
         "retrieve error data"
         col_offset = -1
-        if self.node is not None:
+        if self.node != None:
             try:
                 col_offset = self.node.col_offset
             except AttributeError:

--- a/fehmpytests/tpl_write/parameter.py
+++ b/fehmpytests/tpl_write/parameter.py
@@ -26,7 +26,7 @@ def valid_symbol_name(name):
     "input is a valid name"
     if name in RESERVED_WORDS:
         return False
-    return NAME_MATCH(name) is not None
+    return NAME_MATCH(name) != None
 
 
 class Parameters(OrderedDict):
@@ -48,7 +48,7 @@ class Parameters(OrderedDict):
         if key not in self:
             if not valid_symbol_name(key):
                 raise KeyError("'%s' is not a valid Parameters name" % key)
-        if value is not None and not isinstance(value, Parameter):
+        if value != None and not isinstance(value, Parameter):
             raise ValueError("'%s' is not a Parameter" % value)
         OrderedDict.__setitem__(self, key, value)
         value.name = key
@@ -98,24 +98,24 @@ class Parameter(object):
         self.deps   = None
         self.stderr = None
         self.correl = None
-        if self.max is not None and value > self.max:
+        if self.max != None and value > self.max:
             self._val = self.max
-        if self.min is not None and value < self.min:
+        if self.min != None and value < self.min:
             self._val = self.min
         self.from_internal = lambda val: val
 
     def __repr__(self):
         s = []
-        if self.name is not None:
+        if self.name != None:
             s.append("'%s'" % self.name)
         sval = repr(self._val)
-        if self.stderr is not None:
+        if self.stderr != None:
             sval = "value=%s +/- %.3g" % (sval, self.stderr)
-        if not self.vary and self.expr is None:
+        if not self.vary and self.expr == None:
             sval = "value=%s (fixed)" % (sval)
         s.append(sval)
         s.append("bounds=[%s:%s]" % (repr(self.min), repr(self.max)))
-        if self.expr is not None:
+        if self.expr != None:
             s.append("expr='%s'" % (self.expr))
         return "<Parameter %s>" % ', '.join(s)
 
@@ -166,13 +166,13 @@ class Parameter(object):
 
     def _getval(self):
         """get value, with bounds applied"""
-        if (self._val is not nan and
+        if (self._val != nan and
             isinstance(self._val, uncertainties.Variable)):
             self._val = self._val.nominal_value
 
-        if self.min is None:
+        if self.min == None:
             self.min = -inf
-        if self.max is None:
+        if self.max == None:
             self.max =  inf
         if self.max < self.min:
             self.max, self.min = self.min, self.max

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ DEPEND = ${SRCDIR}Makefile.depends
 OPSYS = $(shell uname -s )
 DATETAG = $(shell date '+%y-%m-%d')
 DATE = $(shell date '+.%d%b%y')
-FFLAGS = -frecord-marker=4 -no-pie
+FFLAGS = -frecord-marker=4 -no-pie -fallow-argument-mismatch
 DEBUGFLAGS = -g -O0 -frecord-marker=4 -fbounds-check -Wall
 
 


### PR DESCRIPTION
fixed an error with the newer fortran compilers throwing errors for previous warnings as well as with leftover python2 code that was causing issues for Windows